### PR TITLE
Fixed to execute Pushy.listen() after registration has been completed

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -12,11 +12,11 @@ function createWindow() {
 
     // On window load listener
     win.webContents.on('did-finish-load', () => {
-        // Listen for notifications
-        Pushy.listen();
-
         // Register device for push notifications
         Pushy.register({ appId: '550ee57c5b5d72117f51e801' }).then((deviceToken) => {
+            // Listen for notifications and connectivity
+            Pushy.listen();
+
             // Display an alert with device token
             Pushy.alert(win, 'Pushy device token: ' + deviceToken);
         }).catch((err) => {


### PR DESCRIPTION
Here is a correction on the implementation example. 🙏 

I think `Pushy.listen()` should be executed after `Pushy.register()` is completed, since it seems to be implemented assuming that registration is complete.
https://github.com/pushy/pushy-electron/blob/cc979fea1563219a52b4b695df719b27870a88ce/util/mqtt.js#L8-L10